### PR TITLE
fix missing mailer and lfs minio settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 
 Ansible role to install and configure [forgejo](https://forgejo.org/) on various linux systems.
 
-Forgejo is a self-hosted lightweight software forge.  
-Easy to install and low maintenance, it just does the job. 
+Forgejo is a self-hosted lightweight software forge.
+Easy to install and low maintenance, it just does the job.
 
 
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/bodsch/ansible-forgejo/main.yml?branch=main)][ci]
@@ -527,8 +527,16 @@ forgejo_indexer:
   max_file_size: 1048576
 
 forgejo_lfs:
+  # storage type, currently supported: local, minio
   storage_type: local
   path: data/lfs
+
+  minio_base_path: ""
+  minio_endpoint: ""
+  minio_access_key_id: ""
+  minio_secret_access_key: ""
+  minio_bucket: ""
+  minio_location: ""
 
 forgejo_log:
   root_path: ""
@@ -1431,7 +1439,7 @@ forgejo_auths:
     bind_dn: ""                                   # The DN to bind to the LDAP server with when searching for the user.
     bind_password: ""                             # The password for the Bind DN, if any.
     attributes_in_bind: ""                        # Fetch attributes in bind DN context.
-    synchronize_users: ""                         # Enable/ Disable user synchronization.  
+    synchronize_users: ""                         # Enable/ Disable user synchronization.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -1321,15 +1321,6 @@ forgejo_storage:
     storage_type: local
   packages:
     storage_type: local
-  my_minio:
-    storage_type: minio
-    minio_endpoint: localhost:9000
-    minio_access_key_id: ""
-    minio_secret_access_key: ""
-    minio_bucket: forgejo
-    minio_location: us-east-1
-    minio_use_ssl: false
-    minio_insecure_skip_verify: false
   actions_log:
     storage_type: local
 

--- a/templates/conf/forgejo.d/lfs.j2
+++ b/templates/conf/forgejo.d/lfs.j2
@@ -1,8 +1,29 @@
 
 [lfs]
   {% if forgejo_lfs.storage_type | default('') | string | length > 0 %}
-STORAGE_TYPE = local
+STORAGE_TYPE = {{ forgejo_lfs.storage_type }}
   {% endif %}
-  {% if forgejo_lfs.path | default('') | string | length > 0 %}
-PATH = data/lfs
+  {% if forgejo_lfs.storage_type == "local" %}
+    {% if forgejo_lfs.path | default('') | string | length > 0 %}
+PATH = {{ forgejo_lfs.path }}
+    {% endif %}
+  {% endif %}
+
+  {% if forgejo_lfs.minio_base_path | default('') | string | length > 0 %}
+MINIO_BASE_PATH = {{ forgejo_lfs.minio_base_path }}
+  {% endif %}
+  {% if forgejo_lfs.minio_endpoint | default('') | string | length > 0 %}
+MINIO_ENDPOINT = {{ forgejo_lfs.minio_endpoint }}
+  {% endif %}
+  {% if forgejo_lfs.minio_access_key_id | default('') | string | length > 0 %}
+MINIO_ACCESS_KEY_ID = {{ forgejo_lfs.minio_access_key_id }}
+  {% endif %}
+  {% if forgejo_lfs.minio_secret_access_key | default('') | string | length > 0 %}
+MINIO_SECRET_ACCESS_KEY = {{ forgejo_lfs.minio_secret_access_key }}
+  {% endif %}
+  {% if forgejo_lfs.minio_bucket | default('') | string | length > 0 %}
+MINIO_BUCKET = {{ forgejo_lfs.minio_bucket }}
+  {% endif %}
+  {% if forgejo_lfs.minio_location | default('') | string | length > 0 %}
+MINIO_LOCATION = {{ forgejo_lfs.minio_location }}
   {% endif %}

--- a/templates/conf/forgejo.d/lfs.j2
+++ b/templates/conf/forgejo.d/lfs.j2
@@ -9,21 +9,23 @@ PATH = {{ forgejo_lfs.path }}
     {% endif %}
   {% endif %}
 
-  {% if forgejo_lfs.minio_base_path | default('') | string | length > 0 %}
+  {% if forgejo_lfs.storage_type == "minio" %}
+    {% if forgejo_lfs.minio_base_path | default('') | string | length > 0 %}
 MINIO_BASE_PATH = {{ forgejo_lfs.minio_base_path }}
-  {% endif %}
-  {% if forgejo_lfs.minio_endpoint | default('') | string | length > 0 %}
+    {% endif %}
+    {% if forgejo_lfs.minio_endpoint | default('') | string | length > 0 %}
 MINIO_ENDPOINT = {{ forgejo_lfs.minio_endpoint }}
-  {% endif %}
-  {% if forgejo_lfs.minio_access_key_id | default('') | string | length > 0 %}
+    {% endif %}
+    {% if forgejo_lfs.minio_access_key_id | default('') | string | length > 0 %}
 MINIO_ACCESS_KEY_ID = {{ forgejo_lfs.minio_access_key_id }}
-  {% endif %}
-  {% if forgejo_lfs.minio_secret_access_key | default('') | string | length > 0 %}
+    {% endif %}
+    {% if forgejo_lfs.minio_secret_access_key | default('') | string | length > 0 %}
 MINIO_SECRET_ACCESS_KEY = {{ forgejo_lfs.minio_secret_access_key }}
-  {% endif %}
-  {% if forgejo_lfs.minio_bucket | default('') | string | length > 0 %}
+    {% endif %}
+    {% if forgejo_lfs.minio_bucket | default('') | string | length > 0 %}
 MINIO_BUCKET = {{ forgejo_lfs.minio_bucket }}
-  {% endif %}
-  {% if forgejo_lfs.minio_location | default('') | string | length > 0 %}
+    {% endif %}
+    {% if forgejo_lfs.minio_location | default('') | string | length > 0 %}
 MINIO_LOCATION = {{ forgejo_lfs.minio_location }}
+    {% endif %}
   {% endif %}

--- a/templates/conf/forgejo.d/mailer.j2
+++ b/templates/conf/forgejo.d/mailer.j2
@@ -4,71 +4,58 @@ ENABLED = {{ forgejo_mailer.enabled | default('false') | bodsch.core.config_bool
   {% if forgejo_mailer.send_buffer_len | default('') | string | length > 0 %}
 SEND_BUFFER_LEN = {{ forgejo_mailer.send_buffer_len }}
   {% endif %}
-;;
-;; Prefix displayed before subject in mail
-;SUBJECT_PREFIX =
-;;
-;; Mail server protocol. One of "smtp", "smtps", "smtp+starttls", "smtp+unix", "sendmail", "dummy".
-;; - sendmail: use the operating system's `sendmail` command instead of SMTP. This is common on Linux systems.
-;; - dummy: send email messages to the log as a testing phase.
-;; If your provider does not explicitly say which protocol it uses but does provide a port,
-;; you can set SMTP_PORT instead and this will be inferred.
-;; (Before 1.18, see the notice, this was controlled via MAILER_TYPE and IS_TLS_ENABLED.)
-;PROTOCOL =
-;;
-;; Mail server address, e.g. smtp.gmail.com.
-;; For smtp+unix, this should be a path to a unix socket instead.
-;; (Before 1.18, see the notice, this was combined with SMTP_PORT as HOST.)
-;SMTP_ADDR =
-;;
-;; Mail server port. Common ports are:
-;;   25:  insecure SMTP
-;;   465: SMTP Secure
-;;   587: StartTLS
-;; If no protocol is specified, it will be inferred by this setting.
-;; (Before 1.18, this was combined with SMTP_ADDR as HOST.)
-;SMTP_PORT =
-;;
-;; Enable HELO operation. Defaults to true.
-;ENABLE_HELO = true
-;;
-;; Custom hostname for HELO operation.
-;; If no value is provided, one is retrieved from system.
-;HELO_HOSTNAME =
-;;
-;; If set to `true`, completely ignores server certificate validation errors.
-;; This option is unsafe. Consider adding the certificate to the system trust store instead.
-;FORCE_TRUST_SERVER_CERT = false
-;;
-;; Use client certificate in connection.
-;USE_CLIENT_CERT = false
-;CLIENT_CERT_FILE = custom/mailer/cert.pem
-;CLIENT_KEY_FILE = custom/mailer/key.pem
-;;
-;; Mail from address, RFC 5322. This can be just an email address, or the `"Name" <email@example.com>` format
-;FROM =
-;;
-;; Sometimes it is helpful to use a different address on the envelope. Set this to use ENVELOPE_FROM as the from on the envelope. Set to `<>` to send an empty address.
-;ENVELOPE_FROM =
-;;
-;; Mailer user name and password, if required by provider.
-;USER =
-;;
-;; Use PASSWD = `your password` for quoting if you use special characters in the password.
-;PASSWD =
-;;
-;; Send mails only in plain text, without HTML alternative
-;SEND_AS_PLAIN_TEXT = false
-;;
-;; Specify an alternative sendmail binary
-;SENDMAIL_PATH = sendmail
-;;
-;; Specify any extra sendmail arguments
-;; WARNING: if your sendmail program interprets options you should set this to "--" or terminate these args with "--"
-;SENDMAIL_ARGS =
-;;
-;; Timeout for Sendmail
-;SENDMAIL_TIMEOUT = 5m
-;;
-;; convert \r\n to \n for Sendmail
-;SENDMAIL_CONVERT_CRLF = true
+  {% if forgejo_mailer.protocol | default('') | string | length > 0 and
+        forgejo_mailer.protocol in ["smtp", "smtps", "smtp+starttls", "smtp+unix", "sendmail", "dummy"] %}
+PROTOCOL = {{ forgejo_mailer.protocol }}
+  {% endif %}
+  {% if forgejo_mailer.smtp_addr | default('') | string | length > 0 %}
+SMTP_ADDR = {{ forgejo_mailer.smtp_addr }}
+  {% endif %}
+  {% if forgejo_mailer.smtp_port | default('') | string | length > 0 %}
+SMTP_PORT = {{ forgejo_mailer.smtp_port }}
+  {% endif %}
+  {% if forgejo_mailer.enable_helo | default('') | string | length > 0 %}
+ENABLE_HELO = {{ forgejo_mailer.enable_helo | bodsch.core.config_bool(true_as='true', false_as='false') }}
+  {% endif %}
+  {% if forgejo_mailer.helo_hostname | default('') | string | length > 0 %}
+HELO_HOSTNAME = {{ forgejo_mailer.helo_hostname }}
+  {% endif %}
+  {% if forgejo_mailer.force_trust_server_cert | default('') | string | length > 0 %}
+FORCE_TRUST_SERVER_CERT = {{ forgejo_mailer.force_trust_server_cert | bodsch.core.config_bool(true_as='true', false_as='false') }}
+  {% endif %}
+  {% if forgejo_mailer.use_client_cert | default('') | string | length > 0 %}
+USE_CLIENT_CERT = {{ forgejo_mailer.use_client_cert | bodsch.core.config_bool(true_as='true', false_as='false') }}
+  {% endif %}
+  {% if forgejo_mailer.client_cert_file | default('') | string | length > 0 %}
+CLIENT_CERT_FILE = {{ forgejo_mailer.client_cert_file }}
+  {% endif %}
+  {% if forgejo_mailer.client_key_file | default('') | string | length > 0 %}
+CLIENT_KEY_FILE = {{ forgejo_mailer.client_key_file }}
+  {% endif %}
+  {% if forgejo_mailer.from | default('') | string | length > 0 %}
+FROM = {{ forgejo_mailer.from }}
+  {% endif %}
+  {% if forgejo_mailer.envelop_from | default('') | string | length > 0 %}
+ENVELOPE_FROM = {{ forgejo_mailer.envelop_from }}
+  {% endif %}
+  {% if forgejo_mailer.user | default('') | string | length > 0 %}
+USER = {{ forgejo_mailer.user }}
+  {% endif %}
+  {% if forgejo_mailer.passwd | default('') | string | length > 0 %}
+PASSWD = {{ forgejo_mailer.passwd }}
+  {% endif %}
+  {% if forgejo_mailer.send_as_plain_text | default('') | string | length > 0 %}
+SEND_AS_PLAIN_TEXT = {{ forgejo_mailer.send_as_plain_text | bodsch.core.config_bool(true_as='true', false_as='false') }}
+  {% endif %}
+  {% if forgejo_mailer.sendmail_path | default('') | string | length > 0 %}
+SENDMAIL_PATH = {{ forgejo_mailer.sendmail_path }}
+  {% endif %}
+  {% if forgejo_mailer.sendmail_args | default('') | string | length > 0 %}
+SENDMAIL_ARGS = {{ forgejo_mailer.sendmail_args }}
+  {% endif %}
+  {% if forgejo_mailer.sendmail_timeout | default('') | string | length > 0 %}
+SENDMAIL_TIMEOUT = {{ forgejo_mailer.sendmail_timeout }}
+  {% endif %}
+  {% if forgejo_mailer.sendmail_convert_crlf | default('') | string | length > 0 %}
+SENDMAIL_CONVERT_CRLF = {{ forgejo_mailer.sendmail_convert_crlf | bodsch.core.config_bool(true_as='true', false_as='false') }}
+  {% endif %}

--- a/templates/conf/forgejo.d/storage.j2
+++ b/templates/conf/forgejo.d/storage.j2
@@ -3,6 +3,38 @@
   {% if forgejo_storage.storage_type | default('') | string | length > 0 %}
 STORAGE_TYPE = {{ forgejo_storage.storage_type }}
   {% endif %}
+  {% if forgejo_storage.storage_type == "local" %}
+    {% if forgejo_storage.path | default('') | string | length > 0 %}
+PATH = {{ forgejo_storage.path }}
+    {% endif %}
+  {% endif %}
+
+  {% if forgejo_storage.storage_type == "minio" %}
+    {% if forgejo_storage.serve_direct | default('') | string | length > 0 %}
+SERVE_DIRECT = {{ forgejo_storage.serve_direct | bodsch.core.config_bool(true_as='true', false_as='false') }}
+    {% endif %}
+    {% if forgejo_storage.minio_endpoint | default('') | string | length > 0 %}
+MINIO_ENDPOINT = {{ forgejo_storage.minio_endpoint }}
+    {% endif %}
+    {% if forgejo_storage.minio_access_key_id | default('') | string | length > 0 %}
+MINIO_ACCESS_KEY_ID = {{ forgejo_storage.minio_access_key_id }}
+    {% endif %}
+    {% if forgejo_storage.minio_secret_access_key | default('') | string | length > 0 %}
+MINIO_SECRET_ACCESS_KEY = {{ forgejo_storage.minio_secret_access_key }}
+    {% endif %}
+    {% if forgejo_storage.minio_bucket | default('') | string | length > 0 %}
+MINIO_BUCKET = {{ forgejo_storage.minio_bucket }}
+    {% endif %}
+    {% if forgejo_storage.minio_location | default('') | string | length > 0 %}
+MINIO_LOCATION = {{ forgejo_storage.minio_location }}
+    {% endif %}
+    {% if forgejo_storage.minio_use_ssl | default('') | string | length > 0 %}
+MINIO_USE_SSL = {{ forgejo_storage.minio_use_ssl | bodsch.core.config_bool(true_as='true', false_as='false') }}
+    {% endif %}
+    {% if forgejo_storage.minio_insecure_skip_verify | default('') | string | length > 0 %}
+MINIO_INSECURE_SKIP_VERIFY = {{ forgejo_storage.minio_insecure_skip_verify | bodsch.core.config_bool(true_as='true', false_as='false') }}
+    {% endif %}
+  {% endif %}
   {% if forgejo_storage.repo_archive is defined and
         forgejo_storage.repo_archive | count > 0 %}
 
@@ -15,39 +47,11 @@ STORAGE_TYPE = {{ forgejo_storage.repo_archive.storage_type }}
         forgejo_storage.packages | count > 0 %}
 
 [storage.packages]
-    {% if forgejo_storage.packages.storage_type | default('') | string | length > 0 %}
+  {% if forgejo_storage.packages.storage_type | default('') | string | length > 0 %}
 STORAGE_TYPE = {{ forgejo_storage.packages.storage_type }}
     {% endif %}
   {% endif %}
-  {% if forgejo_storage.my_minio is defined and
-        forgejo_storage.my_minio | count > 0 %}
 
-[storage.my_minio]
-    {% if forgejo_storage.my_minio.storage_type | default('') | string | length > 0 %}
-STORAGE_TYPE = {{ forgejo_storage.my_minio.storage_type }}
-    {% endif %}
-    {% if forgejo_storage.my_minio.minio_endpoint | default('') | string | length > 0 %}
-MINIO_ENDPOINT = {{ forgejo_storage.my_minio.minio_endpoint }}
-    {% endif %}
-    {% if forgejo_storage.my_minio.minio_access_key_id | default('') | string | length > 0 %}
-MINIO_ACCESS_KEY_ID = {{ forgejo_storage.my_minio.minio_access_key_id }}
-    {% endif %}
-    {% if forgejo_storage.my_minio.minio_secret_access_key | default('') | string | length > 0 %}
-MINIO_SECRET_ACCESS_KEY = {{ forgejo_storage.my_minio.minio_secret_access_key }}
-    {% endif %}
-    {% if forgejo_storage.my_minio.minio_bucket | default('') | string | length > 0 %}
-MINIO_BUCKET = {{ forgejo_storage.my_minio.minio_bucket }}
-    {% endif %}
-    {% if forgejo_storage.my_minio.minio_location | default('') | string | length > 0 %}
-MINIO_LOCATION = {{ forgejo_storage.my_minio.minio_location }}
-    {% endif %}
-    {% if forgejo_storage.my_minio.minio_use_ssl | default('') | string | length > 0 %}
-MINIO_USE_SSL = {{ forgejo_storage.my_minio.minio_use_ssl | bodsch.core.config_bool(true_as='true', false_as='false') }}
-    {% endif %}
-    {% if forgejo_storage.my_minio.minio_insecure_skip_verify | default('') | string | length > 0 %}
-MINIO_INSECURE_SKIP_VERIFY = {{ forgejo_storage.my_minio.minio_insecure_skip_verify | bodsch.core.config_bool(true_as='true', false_as='false') }}
-    {% endif %}
-  {% endif %}
   {% if forgejo_storage.actions_log is defined and
         forgejo_storage.actions_log | count > 0 %}
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -842,20 +842,20 @@ forgejo_defaults_ssh:
     # dsa: -1
 
 forgejo_defaults_storage:
-  storage_type: ""                                # local
+  storage_type: ""                                # local, minio
+  path: ""
+  serve_direct: ""                              # false
+  minio_endpoint: ""                            # localhost:9000
+  minio_access_key_id: ""
+  minio_secret_access_key: ""
+  minio_bucket: ""                              # forgejo
+  minio_location: ""                            # us-east-1
+  minio_use_ssl: ""                             # false
+  minio_insecure_skip_verify: ""                # false
   repo_-archive:
     storage_type: ""                              # local
   packages:
     storage_type: ""                              # local
-  my_minio:
-    storage_type: ""                              # minio
-    minio_endpoint: ""                            # localhost:9000
-    minio_access_key_id: ""
-    minio_secret_access_key: ""
-    minio_bucket: ""                              # forgejo
-    minio_location: ""                            # us-east-1
-    minio_use_ssl: ""                             # false
-    minio_insecure_skip_verify: ""                # false
   actions_log:
     storage_type: ""                              # local
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -367,8 +367,15 @@ forgejo_defaults_indexer:
   max_file_size: ""                               # 1048576
 
 forgejo_defaults_lfs:
-  storage_type: ""                                # local
+  storage_type: "local"                           # local, minio
   path: ""                                        # data/lfs
+
+  minio_base_path: ""
+  minio_endpoint: ""
+  minio_access_key_id: ""
+  minio_secret_access_key: ""
+  minio_bucket: ""
+  minio_location: ""
 
 forgejo_defaults_log:
   root_path: ""


### PR DESCRIPTION
Allows to configure the mailer settings, and allows to use local and minio storage for LFS. In addition I swapped out the minio configuration in the global storage settings for a more generic version.